### PR TITLE
Fix multiple question opening bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,8 +417,15 @@
             fabric: 0,
             combination: 0
         };
+        let questionAnswered = false; // Flag to prevent multiple answers
         
         function answer(questionId, value) {
+            // Prevent multiple answers for the same question
+            if (questionAnswered) {
+                return;
+            }
+            
+            questionAnswered = true;
             answers[questionId] = value;
             
             // Visuelles Feedback
@@ -440,6 +447,7 @@
                 } else {
                     showResult();
                 }
+                questionAnswered = false; // Reset flag for next question
             }, 300);
         }
         
@@ -856,6 +864,7 @@
             Object.keys(answers).forEach(key => delete answers[key]);
             currentQuestion = 1;
             scores = { databricks: 0, fabric: 0, combination: 0 };
+            questionAnswered = false; // Reset question flag
             
             // Reset UI
             document.querySelectorAll('.decision-container').forEach((container, index) => {


### PR DESCRIPTION
## Summary
- Fix bug where multiple questions would open when clicking answer buttons repeatedly
- Implement proper sequential question flow (Q1 → Q2 → Q3, etc.)
- Add protection against multiple clicks on the same question

## Problem
Previously, users could click answer buttons multiple times before the timeout completed, causing multiple questions to open simultaneously and breaking the intended sequential flow.

## Solution
**🔒 Answer Protection**
- Added `questionAnswered` flag to prevent multiple answers per question
- Function returns early if question is already answered
- Flag is reset after timeout to allow next question

**📋 Sequential Flow**
- Ensures only one question can be active at a time
- Maintains proper progression through all 10 questions
- Prevents UI confusion and broken user experience

**♻️ Reset Functionality**
- Flag is properly reset in `resetQuiz()` function
- Ensures clean state when starting over

## Technical Changes
```javascript
// Added protection flag
let questionAnswered = false;

// Modified answer function
function answer(questionId, value) {
    if (questionAnswered) {
        return; // Prevent multiple answers
    }
    questionAnswered = true;
    // ... rest of logic
    setTimeout(() => {
        // ... show next question
        questionAnswered = false; // Reset for next question
    }, 300);
}
```

## Test plan
- [x] Single click advances to next question properly
- [x] Multiple rapid clicks don't open multiple questions
- [x] Sequential flow maintained (Q1 → Q2 → Q3, etc.)
- [x] Reset functionality works correctly
- [x] All 10 questions flow properly to final result

🤖 Generated with [Claude Code](https://claude.ai/code)