### PR TITLE
Properly fix multiple question opening bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,15 +417,13 @@
             fabric: 0,
             combination: 0
         };
-        let questionAnswered = false; // Flag to prevent multiple answers
         
         function answer(questionId, value) {
             // Prevent multiple answers for the same question
-            if (questionAnswered) {
-                return;
+            if (answers[questionId] !== undefined) {
+                return; // Question already answered
             }
             
-            questionAnswered = true;
             answers[questionId] = value;
             
             // Visuelles Feedback
@@ -447,7 +445,6 @@
                 } else {
                     showResult();
                 }
-                questionAnswered = false; // Reset flag for next question
             }, 300);
         }
         
@@ -864,7 +861,6 @@
             Object.keys(answers).forEach(key => delete answers[key]);
             currentQuestion = 1;
             scores = { databricks: 0, fabric: 0, combination: 0 };
-            questionAnswered = false; // Reset question flag
             
             // Reset UI
             document.querySelectorAll('.decision-container').forEach((container, index) => {


### PR DESCRIPTION
## Summary
- Fix persistent bug where repeated clicks on the same answer button would open multiple questions
- Implement proper per-question answer validation instead of global flag
- Remove unnecessary code and simplify logic

## Problem
The previous fix using a global `questionAnswered` flag was inadequate because:
- It prevented multiple clicks globally but not per specific question
- Users could still click the same answer button multiple times to advance multiple questions
- The sequential flow (Q1 → Q2 → Q3) was broken

## Solution
**🎯 Specific Question Validation**
```javascript
// OLD: Global flag approach (inadequate)
if (questionAnswered) {
    return;
}

// NEW: Per-question validation (correct)
if (answers[questionId] \!== undefined) {
    return; // Question already answered
}
```

**🧹 Code Cleanup**
- Removed unnecessary `questionAnswered` flag
- Simplified timeout logic
- Cleaner reset functionality

**✅ Proper Sequential Flow**
- Each question can only be answered once
- Q1 answer → only Q2 opens
- Q2 answer → only Q3 opens
- And so on...

## Technical Changes
1. **Per-question check**: `if (answers[questionId] \!== undefined)` prevents re-answering
2. **Removed global flag**: Eliminated `questionAnswered` variable and related code
3. **Simplified timeout**: Removed unnecessary flag reset in timeout
4. **Clean reset**: Removed flag reset from `resetQuiz()` function

## Test plan
- [x] Click Q1 answer once → Q2 opens
- [x] Click Q1 answer again → Nothing happens (Q3 does not open)
- [x] Click Q2 answer once → Q3 opens
- [x] Click Q2 answer again → Nothing happens (Q4 does not open)
- [x] Sequential flow maintained through all 10 questions
- [x] Reset functionality works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)